### PR TITLE
テスト修正等

### DIFF
--- a/lib/gyazo/client.rb
+++ b/lib/gyazo/client.rb
@@ -59,12 +59,13 @@ module Gyazo
         if File.exist? imagefile and RUBY_PLATFORM =~ /darwin/
           system "sips -s format png \"#{imagefile}\" --out \"#{tmpfile}\" > /dev/null"
         end
+        imagefile = tmpfile
       end
 
       res = HTTMultiParty.post "#{@host}/upload.cgi", {
         :query => {
           :id => @id,
-          :imagedata => File.new(imagefile)
+          :imagedata => File.open(imagefile)
         },
         :header => {
           'User-Agent' => @user_agent

--- a/test/test_gyazo.rb
+++ b/test/test_gyazo.rb
@@ -5,12 +5,12 @@ class TestGyazo < MiniTest::Test
   def setup
     @gyazo = Gyazo::Client.new
     @imagefile = File.expand_path 'test.png', File.dirname(__FILE__)
-    @image_id = "a2a2a8154340bd33e9cd5eeea1efd832"
+    @image_id = Digest::MD5.hexdigest File.open(@imagefile).read
   end
 
   def test_upload
     url = @gyazo.upload @imagefile
-    assert_equal url, "#{@gyazo.host}/#{@image_id}"
+    assert url.match /^#{@gyazo.host}\/[a-z\d]{32}$/
   end
 
   def test_id


### PR DESCRIPTION
## gyazoの仕様が変わってテストが通らなかった箇所を修正しました

- 今まではアップロードした時に付くIDは、ファイルのMD5 hexdigestだった
- 現在はユーザーIDごとに異なるIDがファイルに付く


## MacOSでsipsを通す

- sipsを通してファイルをpngに変換する部分は動いていた
- 変換したファイルではなく、変換前のファイルをアップロードしてしまうバグが有ったので修正しました
